### PR TITLE
bump linked_hashmap to 0.5.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ file = ["log4rs/file", "serde", "serde_derive", "serde-value", "humantime"]
 [dependencies]
 antidote = "1.0"
 humantime = { version = "1.0", optional = true }
-linked-hash-map = "0.5"
+linked-hash-map = "0.5.3"
 log = "0.4"
 log-mdc = { version = "0.1", optional = true }
 log4rs = { version = "0.8", default_features = false }


### PR DESCRIPTION
Linked_hashmap is unsound for versions prior to 0.5.3. This can be found in the [advisory](https://github.com/RustSec/advisory-db/issues/298). This was found from a crater run. Bumping the dependency so that all dependents end up on a sound version of the crate.